### PR TITLE
Make yaml? accept empty hashes as valid yaml expressions

### DIFF
--- a/yaml/yaml.rkt
+++ b/yaml/yaml.rkt
@@ -29,7 +29,6 @@
            (not (null? v))
            (andmap yaml? v))
       (and (hash? v)
-           (not (zero? (hash-count v)))
            (for/and ([(key val) v])
              (and (yaml? key)
                   (yaml? val))))


### PR DESCRIPTION
The `yaml?` function explicitly rejects empty hashes, but the YAML spec allows the definition of empty maps using flow mappings ('{ ... }').  This makes a lot of valid documents fail (see https://github.com/mustache/spec/blob/master/specs/comments.yml for an example).
