### PR TITLE
line counting information correction

### DIFF
--- a/yaml/scanner.rkt
+++ b/yaml/scanner.rkt
@@ -49,7 +49,7 @@
     
     (super-new)
     
-    (define line 0)
+    (define line 1)
     (define column 0)
     (define index 0)
     (define buffer-length 0)


### PR DESCRIPTION
The full situation is: when I'm working on the converter for Eugleo/magic-racket#71, I found the python version and racket's report problem line are different. But after checking into the yaml file, I found the python one is correct(1053) and this lib report is 1052. Thus, I guess the problem is this lib counting from 0, and fix this problem.